### PR TITLE
Modifiche creazione file CBI

### DIFF
--- a/src/BaseRecord.php
+++ b/src/BaseRecord.php
@@ -98,8 +98,8 @@ abstract class BaseRecord implements RecordInterface
         }
 
         // Pad automatico sulla base del tipo
-        if ($record['tipo'] == 'string') {
-            $value = $this->padString($value, $record['dimensione']);
+        if ($record['tipo'] == 'string' ) {
+            $value = $this->padString($value, $record['dimensione'], isset($record['forzaPadding']) ? $record['forzaPadding'] : "" );
         } elseif ($record['tipo'] == 'numeric') {
             $value = $this->padNumber($value, $record['dimensione']);
         } elseif ($record['tipo'] == 'constant') {
@@ -112,7 +112,7 @@ abstract class BaseRecord implements RecordInterface
     /**
      * @return string
      */
-    protected function padString(?string $string, int $length)
+    protected function padString(?string $string, int $length, $pad = STR_PAD_RIGHT)
     {
         // Sostituzione di alcuni simboli noti
         $replaces = [
@@ -124,7 +124,11 @@ abstract class BaseRecord implements RecordInterface
 
         $string = substr($string, 0, $length);
 
-        return str_pad($string, $length);
+		if ( $pad == STR_PAD_LEFT || $pad == STR_PAD_RIGHT ) {
+			return str_pad($string, $length, " ", $pad);
+		}
+		
+		return str_pad($string, $length, " ");
     }
 
     /**

--- a/src/RiBa/Intestazione.php
+++ b/src/RiBa/Intestazione.php
@@ -6,15 +6,16 @@ namespace DevCode\CBI\RiBa;
  * Classe per gestire l'intestazione del RiBa.
  *
  * @property int    $abi
+ * @property int    $soggetto_veicolatore
  * @property int    $cab
  * @property string $conto
  * @property string $data_creazione
  * @property string $nome_supporto
  * @property string $codice_divisa
- * @property string $ragione_soc1_creditore
- * @property string $ragione_soc2_creditore
+ * @property string $ragione_sociale_creditore
  * @property string $indirizzo_creditore
- * @property string $cap_citta_prov_creditore
+ * @property string $citta_creditore
+ * @property string $partita_iva_o_codice_fiscale_creditore
  * @property string $identificativo_creditore
  * @property string $codice_sia
  * @property bool   $eol
@@ -27,6 +28,13 @@ class Intestazione extends Elemento
      * @var int Valore numerico di 5 cifre
      */
     protected $abi;
+	
+	/**
+     * Codice ABI del soggetto veicolatore.
+     *
+     * @var int Valore numerico di 5 cifre
+     */
+    protected $soggetto_veicolatore;
     /**
      * Codice CAB della banca del creditore.
      *
@@ -54,11 +62,7 @@ class Intestazione extends Elemento
     /**
      * @var string Valore alfanumerico di 24 cifre
      */
-    protected $ragione_soc1_creditore;
-    /**
-     * @var string Valore alfanumerico di 24 cifre
-     */
-    protected $ragione_soc2_creditore;
+    protected $ragione_sociale_creditore;
     /**
      * @var string Valore alfanumerico di 24 cifre
      */
@@ -66,7 +70,11 @@ class Intestazione extends Elemento
     /**
      * @var string Valore alfanumerico di 24 cifre
      */
-    protected $cap_citta_prov_creditore;
+    protected $citta_creditore;
+    /**
+     * @var string Valore alfanumerico di 24 cifre
+     */
+    protected $partita_iva_o_codice_fiscale_creditore;
     /**
      * @var string Valore alfanumerico di 16 cifre, opzionale (default "")
      */
@@ -89,12 +97,13 @@ class Intestazione extends Elemento
             $this->data_creazione,
             $this->nome_supporto,
             $this->codice_divisa,
-            $this->ragione_soc1_creditore,
-            $this->ragione_soc2_creditore,
+            $this->ragione_sociale_creditore,
             $this->indirizzo_creditore,
-            $this->cap_citta_prov_creditore,
+            $this->citta_creditore,
+            $this->partita_iva_o_codice_fiscale_creditore,
             $this->identificativo_creditore,
             $this->codice_sia,
+            $this->soggetto_veicolatore,
             $this->eol,
         ];
     }

--- a/src/RiBa/Records/Record20.php
+++ b/src/RiBa/Records/Record20.php
@@ -8,10 +8,10 @@ use DevCode\CBI\BaseRecord;
  * Classe dedicata alla gestione dei dati per il record 20 del formato CBI.
  *
  * @property string numero_progressivo Numero progressivo della ricevuta, uguale a quello indicato per il record 14 della disposizione.
- * @property string descrizione_creditore_1 Descrizione del creditore (24 caratteri alfanumerici).
- * @property string descrizione_creditore_2 Descrizione del creditore (24 caratteri alfanumerici).
- * @property string descrizione_creditore_3 Descrizione del creditore (24 caratteri alfanumerici).
- * @property string descrizione_creditore_4 Descrizione del creditore (24 caratteri alfanumerici).
+ * @property string descrizione_creditore_1 Descrizione del creditore (24 caratteri alfanumerici): ragione sociale
+ * @property string descrizione_creditore_2 Descrizione del creditore (24 caratteri alfanumerici): indirizzo
+ * @property string descrizione_creditore_3 Descrizione del creditore (24 caratteri alfanumerici): citta
+ * @property string descrizione_creditore_4 Descrizione del creditore (24 caratteri alfanumerici): codice fiscale o partita iva -> allineamento a dx (vedi http://www.m8k.org/tracciatocbinet)
  */
 class Record20 extends BaseRecord
 {
@@ -40,6 +40,7 @@ class Record20 extends BaseRecord
             'inizio' => 83,
             'dimensione' => 24,
             'tipo' => 'string',
+			'forzaPadding' => STR_PAD_LEFT
         ],
     ];
 

--- a/src/RiBa/Records/Record50.php
+++ b/src/RiBa/Records/Record50.php
@@ -34,6 +34,7 @@ class Record50 extends BaseRecord
             'inizio' => 101,
             'dimensione' => 16,
             'tipo' => 'string',
+			'forzaPadding' => STR_PAD_LEFT
         ],
     ];
 

--- a/src/RiBa/Records/RecordIB.php
+++ b/src/RiBa/Records/RecordIB.php
@@ -14,7 +14,7 @@ use DevCode\CBI\BaseRecord;
  * @property string campo_a_disposizione Campo a disposizione dell'Azienda codice_sia_mittente.
  * @property string tipo_flusso Assume il valore: "1" = operazioni generate nell’ambito di attività Market Place.
  * @property string qualificatore_flusso Assume il valore fisso "$".
- * @property string soggetto_veicolare Se i due campi tipo_flusso e qualificatore_flusso sono valorizzati con i valori previsti, deve essere indicato il codice ABI della Banca Gateway MP.
+ * @property string soggetto_veicolatore Se i due campi tipo_flusso e qualificatore_flusso sono valorizzati con i valori previsti, deve essere indicato il codice ABI della Banca Gateway MP.
  * @property string codice_divisa Assume il valore fisso "E" (Euro).
  * @property string centro_applicativo Questo campo è di interesse soltanto della tratta tra Centri Applicativi. Codice ABI del Centro Applicativo destinatario del supporto.
  */
@@ -54,10 +54,9 @@ class RecordIB extends BaseRecord
         'qualificatore_flusso' => [
             'inizio' => 106,
             'dimensione' => 1,
-            'tipo' => 'constant',
-            'valore' => '$',
+            'tipo' => 'string',
         ],
-        'soggetto_veicolare' => [
+        'soggetto_veicolatore' => [
             'inizio' => 107,
             'dimensione' => 5,
             'tipo' => 'string',

--- a/src/RiBa/RiBa.php
+++ b/src/RiBa/RiBa.php
@@ -93,8 +93,11 @@ class RiBa
         $ib->nome_supporto = $intestazione->nome_supporto;
         $ib->data_creazione = $intestazione->data_creazione;
 
-        $ib->tipo_flusso = 1;
-        $ib->soggetto_veicolare = $intestazione->abi;
+		if ( $intestazione->soggetto_veicolatore != "" ) {
+			$ib->tipo_flusso = 1;
+			$ib->qualificatore_flusso = '$';
+		}
+        $ib->soggetto_veicolatore = $intestazione->soggetto_veicolatore;
         $contenuto .= $ib->toCBI().$eol;
 
         // Iterazione tra le ricevute interne al RiBa
@@ -123,10 +126,10 @@ class RiBa
             // Record 20
             $r20 = new Record20();
             $r20->numero_progressivo = $progressivo;
-            $r20->descrizione_creditore_1 = $intestazione->ragione_soc1_creditore;
-            $r20->descrizione_creditore_2 = $intestazione->ragione_soc2_creditore;
-            $r20->descrizione_creditore_3 = $intestazione->indirizzo_creditore;
-            $r20->descrizione_creditore_4 = $intestazione->cap_citta_prov_creditore;
+            $r20->descrizione_creditore_1 = $intestazione->ragione_sociale_creditore;
+            $r20->descrizione_creditore_2 = $intestazione->indirizzo_creditore;
+            $r20->descrizione_creditore_3 = $intestazione->citta_creditore;
+            $r20->descrizione_creditore_4 = $intestazione->partita_iva_o_codice_fiscale_creditore;
             $contenuto .= $r20->toCBI().$eol;
 
             // Record 30
@@ -159,7 +162,7 @@ class RiBa
             $r51 = new Record51();
             $r51->numero_progressivo = $progressivo;
             $r51->numero_ricevuta = $ricevuta->numero_ricevuta;
-            $r51->denominazione_creditore = $intestazione->ragione_soc1_creditore;
+            $r51->denominazione_creditore = $intestazione->ragione_sociale_creditore;
             $contenuto .= $r51->toCBI().$eol;
 
             // Record 70


### PR DESCRIPTION
Buongiorno ho fatto delle modifiche alla libreria in quanto tutti i file generati mi venivano scartati dalla banca. In particolare ho seguito le specifiche di controllo dei file txt del sito: http://www.m8k.org/tracciatocbinet dove il rigo 20 era errato nell'utilizzo dei 4 campi descrittivi. Inoltre l'intestazione forzata l'inserimento di 1$<ABI> ma alcune banche lo rifiutato e lo vogliono vuoto quindi l'ho reso facoltativo. Mentre la partita iva / CF nel rigo 20 come sempre da specifiche http://www.m8k.org/tracciatocbinet anche se alfanumerico, usa un pad left di spazi vuoti (come i campi numerici in pratica). Inoltre ho ficxato il campo 51 in quanto non riportata la ragione sociale del creditore